### PR TITLE
fix link and escapeSpecials

### DIFF
--- a/__test__/slackify-markdown.test.js
+++ b/__test__/slackify-markdown.test.js
@@ -137,6 +137,18 @@ test("Link is already encoded", () => {
   expect(slackify(mrkdown)).toBe(slack);
 });
 
+test("Link is already slack style", () => {
+  const mrkdown = "<http://atlassian.com|Atlassian>";
+  const slack = "<http://atlassian.com|Atlassian>\n";
+  expect(slackify(mrkdown)).toBe(slack);
+});
+
+test("String contains '|' but is not a valid link", () => {
+  const mrkdown = "<Atlassian|Atlassian>";
+  const slack = "&lt;Atlassian|Atlassian&gt;\n";
+  expect(slackify(mrkdown)).toBe(slack);
+});
+
 test("Link in reference style with invalid definition", () => {
   const mrkdown = "[Atlassian][test]\n\n[test]: /atlassian";
   const slack = "Atlassian\n";
@@ -248,7 +260,12 @@ test("Code block with deprecated language declaration", () => {
 test("User mention", () => {
   const mrkdown = "<@UPXGB22A2>";
   const slack = "<@UPXGB22A2>\n";
+  expect(slackify(mrkdown)).toBe(slack);
+});
 
+test("Channels link", () => {
+  const mrkdown = "<#UPXGB22A2>";
+  const slack = "<#UPXGB22A2>\n";
   expect(slackify(mrkdown)).toBe(slack);
 });
 


### PR DESCRIPTION
# このPRで修正すること
1. チャンネルリンク形式のとき、リンクが適用されるようにする　`<#channe lD>`
2. すでにslack api のリンク形式のとき、リンクが適用されるようにする　`<url|text>`

# なぜ適用されないか
### 1. チャンネルリンク形式のとき
エスケープされていない

https://github.com/chan-shiro/slackify-markdown/blob/c00503b9920859152e0264de131014b62033b029/src/slackify.js#L9-L21

テストにもこのケースが存在しないため、仕様・または未対応であると考えられる。

### 2. チャンネルリンク形式のとき

`<url|text>`の場合、以下の`Link`で処理されるが

`url=url|text` に変換され、`isURL`でfalseが返るためリンクが適用されていなかった。
（望む挙動としては、phrasingの部分で`url=url, text=text` に変換される）


https://github.com/chan-shiro/slackify-markdown/blob/c00503b9920859152e0264de131014b62033b029/src/slackify.js#L95-L105


# どう修正したか
### 1. チャンネルリンク形式のとき

`<#channe lD>`の場合にもエスケープされるよう修正し、テストを追加

### 2. チャンネルリンク形式のとき

`!isURL(url)`ではない場合、urlに`|`が含まれていればその前後で分解しurlとtextを再設定する。
もし`url|text`ではなく`text|text`であればそのまま返却する。

- phrasingの部分で`url=url, text=text` に変換される or そのまま処理されずに`<url|text>`の形式で返却されるのが正しい姿だと思うのですが、phrasingが`node_modules/mdast-util-to-markdown/lib/util/container-phrasing.js` を利用しているため上記で修正しました。より良い方法があれば教えてほしいです🙇‍♀️


<img width="440" alt="スクリーンショット 2024-10-24 12 08 29" src="https://github.com/user-attachments/assets/e8e7c729-29b9-49a1-8e78-2ec1be99b523">
